### PR TITLE
Solar irradiation correction

### DIFF
--- a/rc_simulator/building_physics.py
+++ b/rc_simulator/building_physics.py
@@ -89,8 +89,8 @@ __credits__ = ["Gabriel Happle, Justin Zarb, Michael Fehr"]
 __license__ = "MIT"
 __version__ = "0.1"
 __maintainer__ = "Prageeth Jayathissa"
-__email__ = "jayathissa@arch.ethz.ch"
-__status__ = "BETA"
+__email__ = "p.jayathissa@gmail.com"
+__status__ = "production"
 
 
 

--- a/rc_simulator/emission_system.py
+++ b/rc_simulator/emission_system.py
@@ -20,8 +20,8 @@ __credits__ = ["CEA Toolbox"]
 __license__ = "MIT"
 __version__ = "0.1"
 __maintainer__ = "Prageeth Jayathissa"
-__email__ = "jayathissa@arch.ethz.ch"
-__status__ = "Development"
+__email__ = "p.jayathissa@gmail.com"
+__status__ = "production"
 
 
 

--- a/rc_simulator/radiation.py
+++ b/rc_simulator/radiation.py
@@ -139,6 +139,7 @@ class Window(object):
         direct_factor = self.calc_direct_solar_factor(sun_altitude, sun_azimuth,)
         diffuse_factor = self.calc_diffuse_solar_factor()
 
+
         direct_solar = direct_factor * normal_direct_radiation
         diffuse_solar = horizontal_diffuse_radiation * diffuse_factor
         self.incident_solar = (direct_solar + diffuse_solar) * self.area
@@ -180,16 +181,18 @@ class Window(object):
         sun_altitude_rad = math.radians(sun_altitude)
         sun_azimuth_rad = math.radians(sun_azimuth)
 
+        # Proportion of the radiation incident on the window (cos of the
+        # incident ray)
+        direct_factor = math.cos(sun_altitude_rad) * math.sin(self.alititude_tilt_rad) * math.cos(sun_azimuth_rad - self.azimuth_tilt_rad) + \
+            math.sin(sun_altitude_rad) * math.cos(self.alititude_tilt_rad)
+
+
         # If the sun is in front of the window surface
-        if math.cos(sun_azimuth_rad - self.azimuth_tilt_rad) > 0:
-            # Proportion of the radiation incident on the window (cos of the
-            # incident ray)
-            direct_factor = math.cos(sun_altitude_rad) * math.cos(sun_azimuth_rad - self.azimuth_tilt_rad) + \
-                math.sin(sun_altitude_rad) * math.cos(self.alititude_tilt_rad)
+        if(math.degrees(math.acos(direct_factor)) > 90):
+            direct_factor=0
 
         else:
-            # If sun is behind the window surface
-            direct_factor = 0
+            pass
 
         return direct_factor
 
@@ -198,69 +201,6 @@ class Window(object):
         # Proportion of incident light on the window surface
         return (1 + math.cos(self.alititude_tilt_rad)) / 2
 
-
-class PhotovoltaicSurface(object):
-    """docstring for Window"""
-
-    def __init__(self, azimuth_tilt, alititude_tilt=90, stc_efficiency=0.16,
-                 performance_ratio=0.8, area=1):
-
-        self.alititude_tilt_rad = math.radians(alititude_tilt)
-        self.azimuth_tilt_rad = math.radians(azimuth_tilt)
-        self.efficiency = stc_efficiency
-        self.performance_ratio = performance_ratio
-        self.area = area
-
-    def calc_solar_yield(self, sun_altitude, sun_azimuth, normal_direct_radiation, horizontal_diffuse_radiation):
-        """
-        Calculates the Solar yield of a defined PV area.
-
-        :param sun_altitude: Altitude Angle of the Sun in Degrees
-        :type sun_altitude: float
-        :param sun_azimuth: Azimuth angle of the sun in degrees
-        :type sun_azimuth: float
-        :param normal_direct_radiation: Normal Direct Radiation from weather file
-        :type normal_direct_radiation: float
-        :param horizontal_diffuse_radiation: Horizontal Diffuse Radiation from weather file
-        :type horizontal_diffuse_radiation: float
-        :return: self.incident_solar, Incident Solar Radiation on window
-        :return: self.solar_gains - Solar gains in building after transmitting through the window
-        :rtype: float
-        """
-
-        direct_factor = self.calc_direct_solar_factor(sun_altitude, sun_azimuth,)
-        diffuse_factor = self.calc_diffuse_solar_factor()
-
-        direct_solar = direct_factor * normal_direct_radiation
-        diffuse_solar = horizontal_diffuse_radiation * diffuse_factor
-        self.incident_solar = (direct_solar + diffuse_solar) * self.area
-
-        self.solar_yield = self.incident_solar * self.efficiency*self.performance_ratio
-
-    def calc_direct_solar_factor(self, sun_altitude, sun_azimuth):
-        """
-        Calculates the cosine of the angle of incidence on the window
-        """
-        sun_altitude_rad = math.radians(sun_altitude)
-        sun_azimuth_rad = math.radians(sun_azimuth)
-
-        # If the sun is in front of the window surface
-        if math.cos(sun_azimuth_rad - self.azimuth_tilt_rad) > 0:
-            # Proportion of the radiation incident on the window (cos of the
-            # incident ray)
-            direct_factor = math.cos(sun_altitude_rad) * math.cos(sun_azimuth_rad - self.azimuth_tilt_rad) + \
-                math.sin(sun_altitude_rad) * math.cos(self.alititude_tilt_rad)
-
-        else:
-            # If sun is behind the window surface
-            direct_factor = 0
-
-        return direct_factor
-
-    def calc_diffuse_solar_factor(self):
-        """Calculates the proportion of diffuse radiation"""
-        # Proportion of incident light on the window surface
-        return (1 + math.cos(self.alititude_tilt_rad)) / 2
 
 if __name__ == '__main__':
     pass

--- a/rc_simulator/radiation.py
+++ b/rc_simulator/radiation.py
@@ -199,7 +199,7 @@ class Window(object):
         return (1 + math.cos(self.alititude_tilt_rad)) / 2
 
 
-class Photovoltaic_surface(object):
+class PhotovoltaicSurface(object):
     """docstring for Window"""
 
     def __init__(self, azimuth_tilt, alititude_tilt=90, stc_efficiency=0.16,

--- a/rc_simulator/radiation.py
+++ b/rc_simulator/radiation.py
@@ -199,5 +199,68 @@ class Window(object):
         return (1 + math.cos(self.alititude_tilt_rad)) / 2
 
 
+class Photovoltaic_surface(object):
+    """docstring for Window"""
+
+    def __init__(self, azimuth_tilt, alititude_tilt=90, stc_efficiency=0.16,
+                 performance_ratio=0.8, area=1):
+
+        self.alititude_tilt_rad = math.radians(alititude_tilt)
+        self.azimuth_tilt_rad = math.radians(azimuth_tilt)
+        self.efficiency = stc_efficiency
+        self.performance_ratio = performance_ratio
+        self.area = area
+
+    def calc_solar_yield(self, sun_altitude, sun_azimuth, normal_direct_radiation, horizontal_diffuse_radiation):
+        """
+        Calculates the Solar yield of a defined PV area.
+
+        :param sun_altitude: Altitude Angle of the Sun in Degrees
+        :type sun_altitude: float
+        :param sun_azimuth: Azimuth angle of the sun in degrees
+        :type sun_azimuth: float
+        :param normal_direct_radiation: Normal Direct Radiation from weather file
+        :type normal_direct_radiation: float
+        :param horizontal_diffuse_radiation: Horizontal Diffuse Radiation from weather file
+        :type horizontal_diffuse_radiation: float
+        :return: self.incident_solar, Incident Solar Radiation on window
+        :return: self.solar_gains - Solar gains in building after transmitting through the window
+        :rtype: float
+        """
+
+        direct_factor = self.calc_direct_solar_factor(sun_altitude, sun_azimuth,)
+        diffuse_factor = self.calc_diffuse_solar_factor()
+
+        direct_solar = direct_factor * normal_direct_radiation
+        diffuse_solar = horizontal_diffuse_radiation * diffuse_factor
+        self.incident_solar = (direct_solar + diffuse_solar) * self.area
+
+        self.solar_yield = self.incident_solar * self.efficiency*self.performance_ratio
+
+    def calc_direct_solar_factor(self, sun_altitude, sun_azimuth):
+        """
+        Calculates the cosine of the angle of incidence on the window
+        """
+        sun_altitude_rad = math.radians(sun_altitude)
+        sun_azimuth_rad = math.radians(sun_azimuth)
+
+        # If the sun is in front of the window surface
+        if math.cos(sun_azimuth_rad - self.azimuth_tilt_rad) > 0:
+            # Proportion of the radiation incident on the window (cos of the
+            # incident ray)
+            direct_factor = math.cos(sun_altitude_rad) * math.cos(sun_azimuth_rad - self.azimuth_tilt_rad) + \
+                math.sin(sun_altitude_rad) * math.cos(self.alititude_tilt_rad)
+
+        else:
+            # If sun is behind the window surface
+            direct_factor = 0
+
+        return direct_factor
+
+    def calc_diffuse_solar_factor(self):
+        """Calculates the proportion of diffuse radiation"""
+        # Proportion of incident light on the window surface
+        return (1 + math.cos(self.alititude_tilt_rad)) / 2
+
 if __name__ == '__main__':
     pass

--- a/rc_simulator/radiation.py
+++ b/rc_simulator/radiation.py
@@ -14,12 +14,12 @@ import datetime
 
 __authors__ = "Prageeth Jayathissa"
 __copyright__ = "Copyright 2016, Architecture and Building Systems - ETH Zurich"
-__credits__ = ["pysolar"]
+__credits__ = ["pysolar, Quaschning Volker,  Rolf Hanitsch, Linus Walker"]
 __license__ = "MIT"
 __version__ = "0.1"
 __maintainer__ = "Prageeth Jayathissa"
-__email__ = "jayathissa@arch.ethz.ch"
-__status__ = "BETA"
+__email__ = "p.jayathissa@gmail.com"
+__status__ = "production"
 
 
 
@@ -183,6 +183,7 @@ class Window(object):
 
         # Proportion of the radiation incident on the window (cos of the
         # incident ray)
+        #ref:Quaschning, Volker, and Rolf Hanitsch. "Shade calculations in photovoltaic systems." ISES Solar World Conference, Harare. 1995.
         direct_factor = math.cos(sun_altitude_rad) * math.sin(self.alititude_tilt_rad) * math.cos(sun_azimuth_rad - self.azimuth_tilt_rad) + \
             math.sin(sun_altitude_rad) * math.cos(self.alititude_tilt_rad)
 

--- a/rc_simulator/supply_system.py
+++ b/rc_simulator/supply_system.py
@@ -15,7 +15,7 @@ __license__ = "MIT"
 __version__ = "0.1"
 __maintainer__ = "Prageeth Jayathissa"
 __email__ = "jayathissa@arch.ethz.ch"
-__status__ = "BETA"
+__status__ = "production"
 
 
 

--- a/rc_simulator/tests/testRadiation.py
+++ b/rc_simulator/tests/testRadiation.py
@@ -97,13 +97,13 @@ class TestRadiation(unittest.TestCase):
         self.assertEqual(round(EastWindow.incident_solar, 2), 570.06)
         self.assertEqual(round(WestWindow.incident_solar, 2), 58.0)
         self.assertEqual(round(NorthWindow.incident_solar, 2), 58.0)
-        self.assertEqual(round(RoofAtrium.incident_solar, 2), 1113.72)
+        self.assertEqual(round(RoofAtrium.incident_solar, 2), 855.87)
 
         self.assertEqual(round(SouthWindow.solar_gains, 2), 221.1)
         self.assertEqual(round(EastWindow.solar_gains, 2), 399.04)
         self.assertEqual(round(WestWindow.solar_gains, 2), 40.6)
         self.assertEqual(round(NorthWindow.solar_gains, 2), 40.6)
-        self.assertEqual(round(RoofAtrium.solar_gains, 2), 779.61)
+        self.assertEqual(round(RoofAtrium.solar_gains, 2), 599.11)
 
         self.assertEqual(
             round(SouthWindow.transmitted_illuminance, 2), 27330.46)
@@ -112,7 +112,7 @@ class TestRadiation(unittest.TestCase):
         self.assertEqual(round(WestWindow.transmitted_illuminance, 2), 6375.2)
         self.assertEqual(round(NorthWindow.transmitted_illuminance, 2), 6375.2)
         self.assertEqual(
-            round(RoofAtrium.transmitted_illuminance, 2), 93833.62)
+            round(RoofAtrium.transmitted_illuminance, 2), 72878.36)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In this branch I fixed the bug that the direct irradiance factor was wrongly set to zero in case of tilted windows having an azimuth difference bigger 90° to the solar azimuth.
Further I added 
`math.sin(self.alititude_tilt_rad)`
as a factor into the direct factor calculation as I think it is necessary for working with tilted windows.